### PR TITLE
fix(desktop-ros2): wrap rviz2 (and rqt) with VirtualGL, not just rviz

### DIFF
--- a/docker/Dockerfile.desktop-ros2
+++ b/docker/Dockerfile.desktop-ros2
@@ -257,8 +257,14 @@ EOF
 RUN chmod +x /usr/local/bin/_vglwrap
 
 # Optional shims for common apps (wrap only if present)
+# rviz2 (not "rviz" -- that's the ROS1 binary name; this image is ROS 2
+# Jazzy only) was missing here, so it ran unwrapped straight against
+# Xvnc's display -- and since Xvnc's own GLX extension is intentionally
+# disabled (see the Xvnc shim above), it failed immediately with
+# `Xlib: extension "GLX" missing on display` instead of getting routed
+# through VirtualGL's EGL backend (confirmed live, 2026-07-24).
 RUN set -eux; \
-        for app in glxinfo glxgears blender gazebo rviz; do \
+        for app in glxinfo glxgears blender gazebo rviz rviz2 rqt; do \
             if command -v "$app" >/dev/null 2>&1; then \
                 real="$(command -v "$app")"; \
                 printf '%s\n' '#!/usr/bin/env bash' "exec /usr/local/bin/_vglwrap \"$real\" \"\$@\"" > "/usr/local/bin/$app"; \


### PR DESCRIPTION
## Summary
Follow-up to #23. After that fix landed, live testing showed `rviz2` fails immediately with `Xlib: extension "GLX" missing on display ":1.0"` — the `_vglwrap` shim list only covered `rviz` (ROS1 binary name), not `rviz2` (the actual ROS 2 Jazzy binary), so it ran unwrapped straight against Xvnc's display instead of being routed through VirtualGL's EGL backend.

## Fix
Add `rviz2` and `rqt` to the wrapped-app list.

## Test plan
- [ ] Rebuild/republish latest-desktop-ros2
- [ ] Respawn gpu-desktop-5gb profile, run `rviz2` in a terminal, confirm it opens a GPU-accelerated render window instead of erroring