### PR TITLE
docs: add mkdocs-material site published to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+# containerMode: kubernetes (the in-cluster self-hosted runner) requires
+# every job to declare a container: image -- there is no bare execution
+# environment.
+jobs:
+  build-docs:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 10
+    container:
+      image: python:3.12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy-docs:
+    if: github.ref == 'refs/heads/main'
+    needs: build-docs
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 10
+    container:
+      image: ubuntu:24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,49 @@
+# CI/CD Pipeline
+
+`.github/workflows/docker-publish.yml` builds and publishes every image
+variant to `ghcr.io/mul-cps/cps-jupyter-notebook`, but only rebuilds the
+variants that actually need it.
+
+## Path-filtered matrix
+
+The `check-changes` job uses `dorny/paths-filter` to detect which
+Dockerfile(s) changed:
+
+- If a **shared** file under `docker/` (anything that isn't a
+  `docker/Dockerfile*`) or the workflow file itself changed, **all six
+  variants** rebuild — a shared hook script or base config change could
+  affect every image.
+- Otherwise, only the variant(s) whose own Dockerfile changed get added to
+  the build matrix (`standard-cpu`, `pytorch-code`, `tf-code`,
+  `desktop-ros2`, `desktop-ros2-xpra`, `comfyui`).
+
+If no variant matched (e.g. a docs-only change), `build-and-push` is
+skipped entirely via
+`if: fromJson(needs.check-changes.outputs.matrix).variant[0] != null`.
+
+## Build and push
+
+Each matched variant builds independently in the `build-and-push` matrix
+job:
+
+- `docker/setup-qemu-action` + `docker/setup-buildx-action` for the build
+- `docker/login-action` to GHCR using the workflow's own `GITHUB_TOKEN`
+- `docker/metadata-action` computes tags: `latest-<suffix>` on `main`,
+  branch-ref and tag-ref variants, and a `sha-<suffix>` tag for every build
+- `docker/build-push-action` builds `linux/amd64` only, using GitHub
+  Actions' own cache backend (`type=gha`), and pushes only on
+  non-`pull_request` events (PRs build but don't push)
+- Two build secrets (`admin_password`, `root_password`) are passed through
+  from repo secrets (`CPS_JUPYTER_ADMIN_PASSWORD`,
+  `CPS_JUPYTER_ROOT_PASSWORD`) for whichever Dockerfile stages need them
+
+A disk-cleanup step runs first on the GitHub-hosted runner (removing
+preinstalled Android/`.NET`/Swift/GHC toolchains, the runner's swap file,
+and pruning the local Docker system) since the GPU-Jupyter base images plus
+CUDA layers are large relative to the runner's default disk.
+
+## Job summary
+
+Every build run appends a small table to the GitHub Actions job summary
+(variant name, Dockerfile path, resulting tags) so you can see at a glance
+what was built without digging through logs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# CPS JupyterHub Notebook Images
+
+This repository builds the JupyterHub single-user notebook images used on the
+`cit-cps-gpu` cluster. It's a set of Dockerfiles — one per variant — layered
+on top of upstream Jupyter/GPU base images, plus a CI pipeline that builds and
+publishes each variant to GHCR whenever its Dockerfile changes.
+
+## What's here
+
+- **`docker/`** — one Dockerfile per notebook variant (standard CPU,
+  PyTorch+code-server, TensorFlow+code-server, ComfyUI, and two ROS 2 desktop
+  variants), plus shared startup hooks (`fix-permissions.sh`,
+  `00-prepare-readonly-home.sh`) baked into every variant.
+- **`.github/workflows/docker-publish.yml`** — path-filtered matrix build:
+  only the variants whose Dockerfile actually changed get rebuilt, unless a
+  shared file or the workflow itself changed, in which case everything
+  rebuilds.
+
+See **[Image Variants](variants.md)** for what each one provides,
+**[Storage Model](storage.md)** for the persistent/ephemeral/shared volume
+layout every variant follows, and **[CI/CD Pipeline](ci-cd.md)** for how
+builds are triggered and published.
+
+## Quick links
+
+- Images: `ghcr.io/mul-cps/cps-jupyter-notebook:<tag>` (see
+  [CI/CD Pipeline](ci-cd.md) for the tagging scheme)
+- Deployed via JupyterHub profiles on the `cit-cps-gpu` cluster (see
+  `mul-cps/cps-gpu-cluster`, `cluster-maintenance/.../user/jupyter/jupyterhub`)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,51 @@
+# Storage Model
+
+Every variant follows the same three-tier volume layout, documented in the
+repo root as `00_IMPORTANT_STORAGE_WARNING.md` and `01_CLUSTER_GUIDE.md`.
+
+| Path | Persistence | Purpose |
+|---|---|---|
+| `/home/jovyan` | **Persistent** | User settings, VS Code extensions, Jupyter config (`.jupyter`, `.config`). Don't put large datasets or build artifacts here — it's not tuned for heavy I/O. |
+| `/home/jovyan/work` | **Ephemeral** | High-performance scratch. All data here is lost on container restart — active computation, compiling, large dataset processing belongs here. |
+| `/home/jovyan/shared` | **Shared** | Mounted for exchanging files with other users/services. |
+
+## Recommended workflow
+
+1. Clone repositories into `/home/jovyan/work` for fast git operations and builds.
+2. Install extensions / configure VS Code — settings persist automatically in `/home/jovyan`.
+3. Copy results you want to keep into `/home/jovyan` or `/home/jovyan/shared` before stopping the container.
+
+## Docker Compose / manual run example
+
+```bash
+docker run -it --rm \
+  -p 8888:8888 \
+  --user root \
+  -e GRANT_SUDO=yes \
+  -v my-home-volume:/home/jovyan \
+  -v /tmp/work:/home/jovyan/work \
+  -v /path/to/shared:/home/jovyan/shared \
+  my-jupyter-image
+```
+
+`/home/jovyan/work` can also be a `tmpfs` mount for maximum I/O speed on
+ephemeral, throwaway scratch (e.g. compiling a ROS 2 workspace).
+
+## Read-only home mounts
+
+If `/home/jovyan` is mounted **read-only** (e.g. a Kubernetes
+`volumeMounts.readOnly: true`), a pre-notebook hook
+(`docker/00-prepare-readonly-home.sh`, baked into every variant) runs first
+and:
+
+- exports `JUPYTER_ENV_VARS_TO_UNSET` (prevents an unbound-variable failure
+  in the base image's own `start.sh`)
+- detects the read-only mount and logs it
+- ensures runtime directories that must be writable actually are
+
+`docker/fix-permissions.sh` was also hardened to degrade gracefully on a
+read-only home: it tries a full recursive `chown` first, falls back to
+`find -writable` for a selective fix if that fails, and always exits `0` so
+a read-only mount never blocks container startup. This is why containers
+start cleanly whether `/home/jovyan` is writable or read-only — no
+configuration needed on either side.

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -1,0 +1,58 @@
+# Image Variants
+
+Each variant is a separate Dockerfile in `docker/`, built independently by
+the CI matrix. All variants except `standard-cpu` are layered on
+`docker.io/cschranz/gpu-jupyter:v1.10_cuda-12.9_ubuntu-24.04_slim` (CUDA
+12.9 / Ubuntu 24.04); `standard-cpu` uses
+`quay.io/jupyter/datascience-notebook:lab-4.5.7` since it has no GPU
+requirement.
+
+## standard-cpu (`docker/Dockerfile`)
+
+Base JupyterLab 4.5.7 image with a curated extension set: `jupyterlab-git`,
+`nbgitpuller`, `jupyter-resource-usage`, `catppuccin-jupyterlab`,
+`jupyterlab-horizon-theme`, `jupyterlab-topbar-text`,
+`lckr-jupyterlab-variableinspector`, `jupyterlab-image-editor`, and more. No
+GPU, no ROS 2, no desktop — for notebook work that doesn't need CUDA.
+
+## pytorch-code (`docker/Dockerfile.pytorch-code`)
+
+GPU-Jupyter base plus `code-server` (VS Code in the browser) for a combined
+notebook + IDE workflow with PyTorch/CUDA available.
+
+## tf-code (`docker/Dockerfile.tf-code`)
+
+Same shape as `pytorch-code`, for TensorFlow workloads instead.
+
+## comfyui (`docker/Dockerfile.comfyui`)
+
+Full [ComfyUI](https://github.com/comfyanonymous/ComfyUI) install (node-based
+Stable Diffusion workflows) with ComfyUI Manager pre-installed, exposed
+through Jupyter via `jupyter-server-proxy` (see `docker/jupyter-comfyui-proxy/`
+for the proxy package) rather than a separate port. GPU-accelerated via the
+CUDA base image.
+
+## desktop-ros2 (`docker/Dockerfile.desktop-ros2`)
+
+A full ROS 2 Jazzy desktop environment accessible via TurboVNC/noVNC,
+including RViz2 and other GL-heavy tools. GPU-accelerated rendering goes
+through **VirtualGL** (`virtualgl_3.1.4_amd64.deb`), with an auto-wrap layer
+so users invoke `rviz2`/`rqt` normally and VirtualGL's EGL backend handles
+GPU acceleration transparently (no need to type `vglrun` by hand) — this
+wraps binaries in place at their own path rather than shadowing them
+elsewhere on `PATH`, which is what makes the auto-wrap actually take effect.
+
+## desktop-ros2-xpra (`docker/Dockerfile.desktop-ros2-xpra`)
+
+The same ROS 2 Jazzy desktop, but using **Xpra** (`xpra`, `xpra-x11`,
+`xpra-html5`, installed from `xpra.org`'s own apt repo) instead of
+TurboVNC/noVNC, for native clipboard support and generally lower-latency
+remote desktop than VNC. `start-xpra-desktop.sh` clears
+`xfce4-panel.xml`/`xfwm4.xml` on every session start to avoid stale
+per-user panel/window-manager state persisting across sessions with a
+different viewport size. Same VirtualGL EGL auto-wrap approach as
+`desktop-ros2` for GPU-accelerated GL apps.
+
+Both desktop variants support an `INCLUDE_VSCODE_DESKTOP` build arg to
+optionally include a full VS Code desktop app in the container (off by
+default, to save CI disk space when not needed).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,49 @@
+site_name: CPS JupyterHub Notebook Images
+site_description: GPU-enabled JupyterHub notebook image variants for the cit-cps-gpu cluster
+repo_url: https://github.com/mul-cps/cps-jupyter-notebook
+repo_name: mul-cps/cps-jupyter-notebook
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: deep orange
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: deep orange
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Image Variants: variants.md
+  - Storage Model: storage.md
+  - CI/CD Pipeline: ci-cd.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - tables
+  - toc:
+      permalink: true


### PR DESCRIPTION
Curated docs (variants, storage model, CI/CD pipeline) built from the actual Dockerfiles/workflow content. Deployed via the in-cluster self-hosted runner.